### PR TITLE
Add support for graphql v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For browser usage also add `[cljsjs.graphql]` in your CLJS file
   - [kw->gql-name](#kw-gql-name)
   - [gql-name->kw](#gql-name-kw)
   - [clj->js-root-value](#clj-js-root-value)
+  - [js->clj-objects](#js->clj-objects)
   - [js->clj-response](#js->clj-response)
   - [add-fields-to-schema-types](#add-fields-to-schema-types)
   - [gql-date->date](#gql-date->date)
@@ -63,6 +64,13 @@ Optionally as a seconds arg you can pass map with `:gql-name->kw` & `:kw->gql-na
 (def root-value (graphql-utils/clj->js-root-value {:a (fn [] {:b 1})}))
 (aget ((aget root-value "a")) "b")
 ;; => 1
+```
+
+#### <a name="js-clj-objects">`js->clj-objects [res]`
+Converts GraphQL request or response object into clj data structures, without keyword naming conversion.
+```clojure
+(graphql-utils/js->clj-objects (clj->js {"data" {"profilePicture_imageHeight" 100}}))
+;; => {:data {:profilePicture_imageHeight 100}}
 ```
 
 #### <a name="js-clj-response">`js->clj-response [res]`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-graphql-utils "1.0.10-SNAPSHOT"
+(defproject district0x/district-graphql-utils "1.0.11-SNAPSHOT"
   :description "Set of functions helpful for working with GraphQL"
   :url "https://github.com/district0x/district-graphql-utils"
   :license {:name "Eclipse Public License"

--- a/src/district/graphql_utils.cljs
+++ b/src/district/graphql_utils.cljs
@@ -102,7 +102,7 @@
       :else root-value)))
 
 
-(defn- js->clj-result-objects [res]
+(defn js->clj-objects [res]
   (walk/prewalk (fn [x]
                   (if (and (nil? (type x))
                            (seq (js-keys x)))
@@ -113,7 +113,7 @@
 
 (defn js->clj-response [res & [opts]]
   (let [gql-name->kw (or (:gql-name->kw opts) gql-name->kw)
-        resp (js->clj-result-objects res)]
+        resp (js->clj-objects res)]
     (update resp :data #(camel-snake-extras/transform-keys gql-name->kw %))))
 
 
@@ -177,7 +177,7 @@
   (if (nil? (aget schema-ast "_typeMap" name))
     (aset schema-ast "_typeMap" name (new (aget GraphQL "GraphQLScalarType")
                                           (clj->js scalar-type-config)))
-    (let [keyword-type (aget schema-ast "_typeMap" name "_scalarConfig")]
+    (let [keyword-type (or (aget schema-ast "_typeMap" name "_scalarConfig") (aget schema-ast "_typeMap" name))]
       (aset keyword-type "parseValue" parseValue)
       (aset keyword-type "parseLiteral" parseLiteral)
       (aset keyword-type "serialize" serialize)))

--- a/test/tests/all.cljs
+++ b/test/tests/all.cljs
@@ -23,6 +23,9 @@
     (is (object? root-value))
     (is (= 1 (aget ((aget root-value "a")) "b"))))
 
+  (let [res (graphql-utils/js->clj-objects (clj->js {"data" {"profilePicture_imageHeight" 100}}))]
+    (is (= res {:data {:profilePicture_imageHeight 100}})))
+
   (let [res (graphql-utils/js->clj-response (clj->js {"data" {"profilePicture_imageHeight" 100}}))]
     (is (= res {:data {:profile-picture/image-height 100}})))
 


### PR DESCRIPTION
Recent versions of graphql lib define scalar types directly within "_typeMap", instead of having a separated "_scalarConfig".
This PR will make the lib work for both older and newer versions.

Additionally, it exposes the function "js->clj-objects" which may be used by dependents libs.