### PR TITLE
Add other alternatives for ID keyword

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-graphql-utils "1.0.11-SNAPSHOT"
+(defproject district0x/district-graphql-utils "1.0.12-SNAPSHOT"
   :description "Set of functions helpful for working with GraphQL"
   :url "https://github.com/district0x/district-graphql-utils"
   :license {:name "Eclipse Public License"

--- a/src/district/graphql_utils.cljs
+++ b/src/district/graphql_utils.cljs
@@ -19,7 +19,7 @@
   :videos.order-by/created-on -> videos_orderBy_createdOn"
   [kw]
   (let [nm (name kw)]
-    (if (#{"ID" "ID!"} nm)
+    (if (#{"ID" "ID!" "[ID]" "[ID!]" "[ID]!" "[ID!]!"} nm)
       nm
       (str
        (when (string/starts-with? nm "__")


### PR DESCRIPTION
Graphql libs automatically convert clojure keyword to GQL name. Such like
`videos.order-by/created-on` -> `videos_orderBy_createdOn`
There is an exception to this and is the scalar type ID, whose conversion do not follow the common kw->gql-name rules, but it remain the same.
ID -> ID, ID! -> ID!, etc.
This PR includes different variations of the keyword when the keyword is included in a list.
ID, ID!, [ID], [ID!], [ID]! and [ID!]!